### PR TITLE
feat: config file & cli bin support

### DIFF
--- a/bin/classcharts-cli.js
+++ b/bin/classcharts-cli.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { spawn } from "child_process";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+// Hacky way to get __dirname in ES modules: https://stackoverflow.com/a/50052194
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Logic from https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/bin/wrangler.js
+spawn(
+  process.execPath,
+  [
+    join(
+      join(__dirname, "..", "dist", "index.js"),
+    ),
+    ...process.argv.slice(2),
+  ],
+  {
+    stdio: "inherit",
+  },
+);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "classcharts-cli",
+  "bin": "./bin/classcharts-cli.js",
   "version": "1.0.0",
   "description": "A CLI for ClassCharts",
   "type": "module",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, render } from "ink";
+import { Box, render, Text } from "ink";
 import React, { useEffect } from "react";
 import Sidebar from "./components/side-bar.js";
 import Table from "./components/table.js";
@@ -8,6 +8,7 @@ import Home from "./components/home.js";
 import fs from "fs";
 import TextInput from "./lib/input.js";
 import { useStudentClient } from "./contexts/student-client.js";
+import { createConfigDirectory } from "./lib/config.js";
 
 const Index = () => {
   const { currentPage } = useCurrentPage();
@@ -16,6 +17,7 @@ const Index = () => {
   const [accessCode, setAccessCode] = React.useState("");
   const [dob, setDob] = React.useState("");
   const { hydrateClient } = useStudentClient();
+  const configDirectory = createConfigDirectory();
 
   const tryLogin = async (options: { accessCode: string; dob: string }) => {
     try {
@@ -33,7 +35,7 @@ const Index = () => {
 
   useEffect(() => {
     try {
-      const account = fs.readFileSync("account.json");
+      const account = fs.readFileSync(configDirectory + "/account.json");
       const { accessCode, dob } = JSON.parse(account.toString());
 
       if (!accessCode || !dob) {
@@ -50,7 +52,7 @@ const Index = () => {
     return (
       <Box flexDirection="column">
         <Box>
-          <Text>Access Code: </Text>
+          <Text>Access Code:</Text>
           <TextInput
             onChange={setAccessCode}
             value={accessCode}
@@ -64,7 +66,7 @@ const Index = () => {
 
         {setup === "dob" && (
           <Box>
-            <Text>Date of Birth {"(DD/MM/YYYY)"}: </Text>
+            <Text>Date of Birth {"(DD/MM/YYYY)"}:</Text>
             <TextInput
               placeholder="04/06/2006"
               onChange={setDob}
@@ -72,11 +74,12 @@ const Index = () => {
               showCursor
               onSubmit={() => {
                 fs.writeFileSync(
-                  "account.json",
+                  configDirectory +
+                    "/account.json",
                   JSON.stringify({
                     accessCode,
                     dob,
-                  })
+                  }),
                 );
 
                 tryLogin({ accessCode, dob });
@@ -109,5 +112,5 @@ const Index = () => {
 render(
   <Providers>
     <Index />
-  </Providers>
+  </Providers>,
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,7 +52,7 @@ const Index = () => {
     return (
       <Box flexDirection="column">
         <Box>
-          <Text>Access Code:</Text>
+          <Text>Access Code:{" "}</Text>
           <TextInput
             onChange={setAccessCode}
             value={accessCode}
@@ -66,7 +66,7 @@ const Index = () => {
 
         {setup === "dob" && (
           <Box>
-            <Text>Date of Birth {"(DD/MM/YYYY)"}:</Text>
+            <Text>Date of Birth {"(DD/MM/YYYY)"}:{" "}</Text>
             <TextInput
               placeholder="04/06/2006"
               onChange={setDob}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,7 +7,7 @@ export function getConfigDirectory() {
       return `${base}/classcharts-cli`;
     case "darwin":
       return `${process.env.HOME}/Library/Application Support/classcharts-cli`;
-    case "win32":
+    case "windows_nt":
       return `${process.env.APPDATA}/classcharts-cli`;
     default:
       throw new Error("Unsupported platform");

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,31 @@
+import { type } from "os";
+import { accessSync, mkdirSync } from "fs";
+export function getConfigDirectory() {
+  switch (type().toLowerCase()) {
+    case "linux":
+      const base = process.env.XDG_CONFIG_HOME ?? `${process.env.HOME}/.config`;
+      return `${base}/classcharts-cli`;
+    case "darwin":
+      return `${process.env.HOME}/Library/Application Support/classcharts-cli`;
+    case "win32":
+      return `${process.env.APPDATA}/classcharts-cli`;
+    default:
+      throw new Error("Unsupported platform");
+  }
+}
+
+export function createConfigDirectory() {
+  const configDirectory = getConfigDirectory();
+  if (exists(configDirectory)) return configDirectory;
+  mkdirSync(configDirectory, { recursive: false });
+  return configDirectory;
+}
+
+export function exists(path: string) {
+  try {
+    accessSync(path);
+  } catch {
+    return false;
+  }
+  return true;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -26,7 +26,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ES6" /* Specify what module code is generated. */,
+    "module": "NodeNext", /* Specify what module code is generated. */
     "moduleResolution": "NodeNext",
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
@@ -79,12 +79,12 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */


### PR DESCRIPTION
- Changed the config file location to central location to aid running the cli from anywhere.
- Added `bin` field in package.json to allow installing the cli globally

## Testing:

I have only tested this PR on Linux, I'm unsure whether it works on Windows and MacOS.

To install the CLI globally, run `npm link` in the root directory of this project.